### PR TITLE
[RFR] Fix servo channel mappings

### DIFF
--- a/wallaby_servo.c
+++ b/wallaby_servo.c
@@ -97,8 +97,8 @@ void TIM3_IRQHandler(void)
         uint32_t servo0_cmd = (((uint32_t)aTxBuffer[REG_RW_SERVO_0_H]) << 8) | ((uint32_t)aTxBuffer[REG_RW_SERVO_0_L]);
         uint32_t servo1_cmd = (((uint32_t)aTxBuffer[REG_RW_SERVO_1_H]) << 8) | ((uint32_t)aTxBuffer[REG_RW_SERVO_1_L]);
 
-        TIM_SetCompare1(TIM3, servo0_cmd);
-        TIM_SetCompare2(TIM3, servo1_cmd);
+        TIM_SetCompare2(TIM3, servo0_cmd);
+        TIM_SetCompare3(TIM3, servo1_cmd);
     }
 }
 


### PR DESCRIPTION
We were using timer channels 2,3 for servo 0,1.... not timer channels 1,2