### PR TITLE
[RFR] MAV,MTP code value consistency

### DIFF
--- a/wallaby_r1.h
+++ b/wallaby_r1.h
@@ -8,8 +8,8 @@
 
 
 #define MOT_MODE_PWM 0
-#define MOT_MODE_MAV 1
-#define MOT_MODE_MTP 2
+#define MOT_MODE_MTP 1
+#define MOT_MODE_MAV 2
 #define MOT_MODE_MRP 3
 
 


### PR DESCRIPTION
Making the firmware match the library (libwallaby).